### PR TITLE
Add instructions to run the Cypress GUI in Docker

### DIFF
--- a/.docker/cypress/entrypoint.sh
+++ b/.docker/cypress/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "💤 Waiting for hitobito to be ready! The first time, this can take a few minutes until the database is seeded."
+echo "💤 Waiting for hitobito to be ready! This can take a few minutes until the database is seeded."
 npx -q wait-on "${CYPRESS_BASE_URL}"
 echo "✅ Hitobito is ready!"
 

--- a/.docker/cypress/entrypoint.sh
+++ b/.docker/cypress/entrypoint.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-echo "💤 Waiting for hitobito to be ready!"
+echo "💤 Waiting for hitobito to be ready! The first time, this can take a few minutes until the database is seeded."
 npx -q wait-on "${CYPRESS_BASE_URL}"
 echo "✅ Hitobito is ready!"
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,14 @@ _It is probably easier, faster and cleaner to use cypress directly (check above)
  4. Run `xhost + $IP` to allow the Docker container to send messages to the X server
  5. Run `DISPLAY=$IP:0 docker-compose run cypress open --project .`
 
+ #### Windows
+
+ _ Not yet tested_
+
+https://dev.to/darksmile92/run-gui-app-in-linux-docker-container-on-windows-host-4kde
+
+When you have set everything up, you should be able to start the same as on the mac…
+ 
  ## Options
 
  ### Different port/base url

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ I.e. you don't have to re-build the Docker images after every code change.
 
  ## Quickstart
 
-### Run tests in docker
+### Run tests in Docker
 
 ```bash
 docker-compose run cypress
@@ -186,6 +186,13 @@ _Note: You can only connect to servers running inside docker-compose. If you nee
  4. Install the testing dependencies (might take a while): `yarn install --frozen-lockfile`
  5. `yarn run ci:wait && yarn run cypress:open`
  6. Start adding tests, they get rerun automatically when open!
+
+### Using GUI in Docker
+ 1. If you are on Mac, install the XQuartz X11 server (`brew cask install xquartz`) and restart your machine
+ 2. Run `xhost local:root` to allow the root user from the Docker container to send messages to the X server
+ 3. `docker-compose up -d cypressserver`
+ 4. Go to `.docker/cypress/spec` in your shell.
+ 5. `docker-compose run cypress-gui`
 
  ## Options
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ _Note: You can only connect to servers running inside docker-compose. If you nee
 #### Linux
  1. Run `xhost local:root` to allow the root user from the Docker container to send messages to the X server
  2. `docker-compose up -d cypressserver`
- 3. `docker-compose run cypress-gui`
+ 3. `docker-compose run cypress open --project .`
 
 #### Mac
 

--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ _It is probably easier, faster and cleaner to use cypress directly (check above)
  2. Open XQuartz, go to settings and "Allow connections from network clients" (further reference [here](https://sourabhbajaj.com/blog/2017/02/07/gui-applications-docker-mac/#run-xquartz)) 
  3. In the project directory, run `IP=$(ipconfig getifaddr en0)`. (You might want to adjust the  `en0` to your network interface of choice…)
  4. Run `xhost + $IP` to allow the Docker container to send messages to the X server
- 5. Run `DISPLAY=$IP:0 docker-compose run cypress open --project .`
+ 5. Run `DISPLAY=$IP:0 docker-compose run cypress-gui`
 
  #### Windows
 

--- a/README.md
+++ b/README.md
@@ -190,9 +190,8 @@ _Note: You can only connect to servers running inside docker-compose. If you nee
 ### Using GUI in Docker
  1. If you are on Mac, install the XQuartz X11 server (`brew cask install xquartz`) and restart your machine
  2. Run `xhost local:root` to allow the root user from the Docker container to send messages to the X server
- 3. `docker-compose up -d cypressserver`
- 4. Go to `.docker/cypress/spec` in your shell.
- 5. `docker-compose run cypress-gui`
+ 3. `docker-compose up -d cypressserver` and wait until the seeds have finished (can take ~5 minutes, you can check using `docker-compose logs cypressserver`)
+ 4. `docker-compose run cypress-gui`
 
  ## Options
 

--- a/README.md
+++ b/README.md
@@ -188,11 +188,20 @@ _Note: You can only connect to servers running inside docker-compose. If you nee
  6. Start adding tests, they get rerun automatically when open!
 
 ### Using GUI in Docker
- 1. If you are on Mac, install the XQuartz X11 server (`brew cask install xquartz`) and restart your machine
- 2. Run `xhost local:root` to allow the root user from the Docker container to send messages to the X server
- 3. `docker-compose up -d cypressserver`
- 4. Go to `.docker/cypress/spec` in your shell.
- 5. `docker-compose run cypress-gui`
+#### Linux
+ 1. Run `xhost local:root` to allow the root user from the Docker container to send messages to the X server
+ 2. `docker-compose up -d cypressserver`
+ 3. `docker-compose run cypress-gui`
+
+#### Mac
+
+_It is probably easier, faster and cleaner to use cypress directly (check above)._
+
+ 1. Install the XQuartz X11 server (`brew cask install xquartz`) and restart your machine
+ 2. Open XQuartz, go to settings and "Allow connections from network clients" (further reference [here](https://sourabhbajaj.com/blog/2017/02/07/gui-applications-docker-mac/#run-xquartz)) 
+ 3. In the project directory, run `IP=$(ipconfig getifaddr en0)`. (You might want to adjust the  `en0` to your network interface of choice…)
+ 4. Run `xhost + $IP` to allow the Docker container to send messages to the X server
+ 5. Run `DISPLAY=$IP:0 docker-compose run cypress open --project .`
 
  ## Options
 

--- a/README.md
+++ b/README.md
@@ -191,8 +191,7 @@ _Note: You can only connect to servers running inside docker-compose. If you nee
 
 #### Linux
  1. Run `xhost local:root` to allow the root user from the Docker container to send messages to the X server
- 2. `docker-compose up -d cypressserver`
- 3. `docker-compose run cypress open --project .`
+ 2. `docker-compose run cypress-gui` This will run hitobito with Cypress (if it is not already running), wait for the seeding to finish and then open the Cypress GUI.
 
 #### Mac
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -79,7 +79,7 @@ services:
     - mail
     - cache  
       
-  cypress:
+  cypress: &cypress
     image: cypress/included:4.3.0
     working_dir: /e2e
     environment:
@@ -92,6 +92,17 @@ services:
     entrypoint: 
       - /bin/entrypoint.sh
     command: ["run"]
+
+  cypress-gui:
+    <<: *cypress
+    environment:
+      - DISPLAY
+      - CYPRESS_BASE_URL=http://cypressserver:3000
+    volumes:
+      - .docker/cypress/spec:/e2e
+      - .docker/cypress/entrypoint.sh:/bin/entrypoint.sh
+      - /tmp/.X11-unix:/tmp/.X11-unix:rw
+    command: ["open"]
 
   # Dependencies
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -83,26 +83,17 @@ services:
     image: cypress/included:4.3.0
     working_dir: /e2e
     environment:
-      - CYPRESS_BASE_URL=http://cypressserver:3000
-    volumes:
-      - .docker/cypress/spec:/e2e
-      - .docker/cypress/entrypoint.sh:/bin/entrypoint.sh
-    depends_on:
-      - cypressserver
-    entrypoint: 
-      - /bin/entrypoint.sh
-    command: ["run"]
-
-  cypress-gui:
-    <<: *cypress
-    environment:
       - DISPLAY
       - CYPRESS_BASE_URL=http://cypressserver:3000
     volumes:
       - .docker/cypress/spec:/e2e
       - .docker/cypress/entrypoint.sh:/bin/entrypoint.sh
       - /tmp/.X11-unix:/tmp/.X11-unix:rw
-    command: ["open"]
+    depends_on:
+      - cypressserver
+    entrypoint: 
+      - /bin/entrypoint.sh
+    command: ["run"]
 
   # Dependencies
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,10 @@ services:
       - /bin/entrypoint.sh
     command: ["run"]
 
+  cypress-gui:
+    <<: *cypress
+    command: ["open", "--project", "."]
+
   # Dependencies
 
   mail:


### PR DESCRIPTION
Vorteile wenn wir das so ins Repo nehmen:
* Anleitung sollte für Mac und Linux funktionieren
* Leute die dieses Repo benützen haben Docker bereits sowieso und müssen sich dann nicht um Yarn und NPM kümmern.

Nachteile:
* Nicht getestet auf Docker for Windows
* ~~Die Services cypress und cypress-gui müssen (wegen der limitierten Funktionalität vom YAML-Inheritance) teilweise manuell synchron gehalten werden~~

PR steht also offen zur Diskussion im Raum.